### PR TITLE
Staging and release app instances

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v1
         with:
           use-public-rspm: true
-        
+
       - uses: r-lib/actions/setup-renv@v1
 
       - name: Install rsconnect


### PR DESCRIPTION
The GH workflow is updated to use *two* ShinyApps applications:
- When code is merged in the `main` branch the app' is deployed to an application named < repo >-staging.  
- When code is merged into any branch starting with `release` then the app' is deployed to an application named < repo >, where < repo > is the GitHub repo' name.

This way we can constantly check the effect of changes merged into the `main` branch and when we are ready to update the production application we explicitly push to a release branch. We can use suffixes (`release-1.0`, `release-2.0`, etc.) to record the history of releases.
